### PR TITLE
Fix duplicate lines and typos in loops

### DIFF
--- a/loops.py
+++ b/loops.py
@@ -11,7 +11,7 @@ while numero <= 10:
 #Imprimindo os números de 10 a 1 com laço while:
 divisoria()
 numero2 = 10
-print("Contando de 10 a 1: (Ordem descrescente)")
+print("Contando de 10 a 1: (Ordem decrescente)")
 
 while numero2 >=1:
     print(numero2)
@@ -19,18 +19,18 @@ while numero2 >=1:
 
 #Solicite ao usuário um número e repita o programa até que o usuário digite 0:
 divisoria()
-print("----------------------------------------------------")
 print("Acerte o número que estou pensando: ")
 numero3 = int(input("Digite um número: "))
 while numero3 != 0:
     print("Você digitou:", numero3,"... Esse não é o número que estou pensando")
     numero3 = int(input("Digite um número: "))
-#Esse caso aqui sempre que eu executava o código ele não retornarva a mensagem de parabéns caso eu acertasse o número   
-    """if numero3 == 0:
-        print("Parabéns, você acertou!")
-        break
-    else:
-        numero3 = int(input("Digite um número: "))"""
+# Esse bloco abaixo não funcionou como esperado e foi mantido apenas
+# como referência de código incorreto.
+# if numero3 == 0:
+#     print("Parabéns, você acertou!")
+#     break
+# else:
+#     numero3 = int(input("Digite um número: "))
 
 print("Parabéns, você acertou!")
 
@@ -39,7 +39,7 @@ print("Parabéns, você acertou!")
 divisoria()
 print("Acerte o número que estou pensando: (Usando IF)")
 while True:
-    numero4 = int(input("Acerte o um número que estou pensando: "))
+    numero4 = int(input("Acerte o número que estou pensando: "))
     if numero4 == 0:
         print("Parabéns, você acertou!")
         break


### PR DESCRIPTION
## Summary
- correct Portuguese typos in `loops.py`
- remove redundant dashed separator

## Testing
- `python loops.py <<'EOF'
0
0
EOF`
- `python loops.py <<'EOF'
1
0
0
EOF`


------
https://chatgpt.com/codex/tasks/task_e_6841db2162148326840500c21ffb8ab8